### PR TITLE
Use fast exceptions for NoSuchElementException on next()

### DIFF
--- a/src/main/java/com/tinkerpop/pipes/branch/ExhaustMergePipe.java
+++ b/src/main/java/com/tinkerpop/pipes/branch/ExhaustMergePipe.java
@@ -1,12 +1,12 @@
 package com.tinkerpop.pipes.branch;
 
+import java.util.List;
+
 import com.tinkerpop.pipes.Pipe;
 import com.tinkerpop.pipes.util.AbstractMetaPipe;
+import com.tinkerpop.pipes.util.FastNoSuchElementException;
 import com.tinkerpop.pipes.util.MetaPipe;
 import com.tinkerpop.pipes.util.PipeHelper;
-
-import java.util.List;
-import java.util.NoSuchElementException;
 
 /**
  * ExhaustiveMergePipe will drain its first internal pipe, then its second, so on until all internal pipes are drained.
@@ -32,7 +32,7 @@ public class ExhaustMergePipe<S> extends AbstractMetaPipe<S, S> implements MetaP
             } else {
                 this.current = (this.current + 1) % this.total;
                 if (this.current == 0) {
-                    throw new NoSuchElementException();
+                    throw FastNoSuchElementException.instance();
                 }
             }
         }

--- a/src/main/java/com/tinkerpop/pipes/branch/FairMergePipe.java
+++ b/src/main/java/com/tinkerpop/pipes/branch/FairMergePipe.java
@@ -1,12 +1,12 @@
 package com.tinkerpop.pipes.branch;
 
+import java.util.List;
+
 import com.tinkerpop.pipes.Pipe;
 import com.tinkerpop.pipes.util.AbstractMetaPipe;
+import com.tinkerpop.pipes.util.FastNoSuchElementException;
 import com.tinkerpop.pipes.util.MetaPipe;
 import com.tinkerpop.pipes.util.PipeHelper;
-
-import java.util.List;
-import java.util.NoSuchElementException;
 
 /**
  * FairMergePipe will, in a round robin fashion, emit the the objects of its internal pipes.
@@ -34,7 +34,7 @@ public class FairMergePipe<S> extends AbstractMetaPipe<S, S> implements MetaPipe
                 this.current = (this.current + 1) % this.total;
                 return s;
             } else if (counter == this.total) {
-                throw new NoSuchElementException();
+                throw FastNoSuchElementException.instance();
             } else {
                 this.current = (this.current + 1) % this.total;
             }

--- a/src/main/java/com/tinkerpop/pipes/filter/RangeFilterPipe.java
+++ b/src/main/java/com/tinkerpop/pipes/filter/RangeFilterPipe.java
@@ -1,9 +1,8 @@
 package com.tinkerpop.pipes.filter;
 
 import com.tinkerpop.pipes.AbstractPipe;
+import com.tinkerpop.pipes.util.FastNoSuchElementException;
 import com.tinkerpop.pipes.util.PipeHelper;
-
-import java.util.NoSuchElementException;
 
 /**
  * The RangeFilterPipe will only allow a sequential subset of its incoming objects to be emitted to its output.
@@ -34,7 +33,7 @@ public class RangeFilterPipe<S> extends AbstractPipe<S, S> implements FilterPipe
                 return s;
             }
             if (this.high != -1 && this.counter > this.high) {
-                throw new NoSuchElementException();
+                throw FastNoSuchElementException.instance();
             }
         }
     }

--- a/src/main/java/com/tinkerpop/pipes/sideeffect/AggregatePipe.java
+++ b/src/main/java/com/tinkerpop/pipes/sideeffect/AggregatePipe.java
@@ -1,15 +1,16 @@
 package com.tinkerpop.pipes.sideeffect;
 
-import com.tinkerpop.pipes.AbstractPipe;
-import com.tinkerpop.pipes.Pipe;
-import com.tinkerpop.pipes.PipeFunction;
-import com.tinkerpop.pipes.util.structures.ArrayQueue;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Queue;
+
+import com.tinkerpop.pipes.AbstractPipe;
+import com.tinkerpop.pipes.Pipe;
+import com.tinkerpop.pipes.PipeFunction;
+import com.tinkerpop.pipes.util.FastNoSuchElementException;
+import com.tinkerpop.pipes.util.structures.ArrayQueue;
 
 /**
  * The AggregatePipe produces a side effect that is the provided Collection filled with the contents of all the objects that have passed through it.
@@ -59,7 +60,7 @@ public class AggregatePipe<S> extends AbstractPipe<S, S> implements SideEffectPi
         while (true) {
             if (this.currentObjectQueue.isEmpty()) {
                 if (!this.starts.hasNext())
-                    throw new NoSuchElementException();
+                    throw FastNoSuchElementException.instance();
                 else {
                     this.currentObjectQueue.clear();
                     this.currentPathQueue.clear();

--- a/src/main/java/com/tinkerpop/pipes/transform/GatherFunctionPipe.java
+++ b/src/main/java/com/tinkerpop/pipes/transform/GatherFunctionPipe.java
@@ -1,13 +1,13 @@
 package com.tinkerpop.pipes.transform;
 
-import com.tinkerpop.pipes.AbstractPipe;
-import com.tinkerpop.pipes.Pipe;
-import com.tinkerpop.pipes.PipeFunction;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.NoSuchElementException;
+
+import com.tinkerpop.pipes.AbstractPipe;
+import com.tinkerpop.pipes.Pipe;
+import com.tinkerpop.pipes.PipeFunction;
+import com.tinkerpop.pipes.util.FastNoSuchElementException;
 
 /**
  * GatherFunctionPipe emits all the objects up to this step as an ArrayList.
@@ -36,7 +36,7 @@ public class GatherFunctionPipe<S, E> extends AbstractPipe<S, E> {
         final List<S> list = new ArrayList<S>();
         this.listPaths = new ArrayList<List>();
         if (!this.starts.hasNext()) {
-            throw new NoSuchElementException();
+            throw FastNoSuchElementException.instance();
         } else {
             while (this.starts.hasNext()) {
                 final S s = this.starts.next();

--- a/src/main/java/com/tinkerpop/pipes/transform/GatherPipe.java
+++ b/src/main/java/com/tinkerpop/pipes/transform/GatherPipe.java
@@ -1,11 +1,11 @@
 package com.tinkerpop.pipes.transform;
 
-import com.tinkerpop.pipes.AbstractPipe;
-import com.tinkerpop.pipes.Pipe;
-
 import java.util.ArrayList;
 import java.util.List;
-import java.util.NoSuchElementException;
+
+import com.tinkerpop.pipes.AbstractPipe;
+import com.tinkerpop.pipes.Pipe;
+import com.tinkerpop.pipes.util.FastNoSuchElementException;
 
 /**
  * GatherPipe emits all the objects up to this step as an ArrayList.
@@ -29,7 +29,7 @@ public class GatherPipe<S> extends AbstractPipe<S, List<S>> {
         final List<S> list = new ArrayList<S>();
         this.listPaths = new ArrayList<List>();
         if (!this.starts.hasNext()) {
-            throw new NoSuchElementException();
+            throw FastNoSuchElementException.instance();
         } else {
             while (this.starts.hasNext()) {
                 final S s = this.starts.next();

--- a/src/main/java/com/tinkerpop/pipes/transform/HasCountPipe.java
+++ b/src/main/java/com/tinkerpop/pipes/transform/HasCountPipe.java
@@ -1,8 +1,7 @@
 package com.tinkerpop.pipes.transform;
 
 import com.tinkerpop.pipes.AbstractPipe;
-
-import java.util.NoSuchElementException;
+import com.tinkerpop.pipes.util.FastNoSuchElementException;
 
 /**
  * @author Darrick Wiebe (http://ofallpossibleworlds.wordpress.com)
@@ -27,7 +26,7 @@ public class HasCountPipe<S> extends AbstractPipe<S, Boolean> {
 
     public Boolean processNextStart() {
         if (this.finished) {
-            throw new NoSuchElementException();
+            throw FastNoSuchElementException.instance();
         }
         this.finished = true;
         if (this.minimum == -1 && this.maximum == -1)

--- a/src/main/java/com/tinkerpop/pipes/transform/OrderPipe.java
+++ b/src/main/java/com/tinkerpop/pipes/transform/OrderPipe.java
@@ -1,16 +1,17 @@
 package com.tinkerpop.pipes.transform;
 
-import com.tinkerpop.pipes.AbstractPipe;
-import com.tinkerpop.pipes.Pipe;
-import com.tinkerpop.pipes.PipeFunction;
-import com.tinkerpop.pipes.util.structures.ArrayQueue;
-import com.tinkerpop.pipes.util.structures.Pair;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.NoSuchElementException;
+
+import com.tinkerpop.pipes.AbstractPipe;
+import com.tinkerpop.pipes.Pipe;
+import com.tinkerpop.pipes.PipeFunction;
+import com.tinkerpop.pipes.util.FastNoSuchElementException;
+import com.tinkerpop.pipes.util.structures.ArrayQueue;
+import com.tinkerpop.pipes.util.structures.Pair;
 
 /**
  * OrderPipe supports in-stream sorting of objects.
@@ -52,7 +53,7 @@ public class OrderPipe<S> extends AbstractPipe<S, S> {
             if (this.pathEnabled) {
                 if (this.bundles.isEmpty()) {
                     if (!this.starts.hasNext())
-                        throw new NoSuchElementException();
+                        throw FastNoSuchElementException.instance();
                     else {
                         this.bundles.clear();
                         try {
@@ -74,7 +75,7 @@ public class OrderPipe<S> extends AbstractPipe<S, S> {
             } else {
                 if (this.objects.isEmpty()) {
                     if (!this.starts.hasNext())
-                        throw new NoSuchElementException();
+                        throw FastNoSuchElementException.instance();
                     else {
                         this.objects.clear();
                         try {

--- a/src/main/java/com/tinkerpop/pipes/transform/SideEffectCapPipe.java
+++ b/src/main/java/com/tinkerpop/pipes/transform/SideEffectCapPipe.java
@@ -1,15 +1,16 @@
 package com.tinkerpop.pipes.transform;
 
-import com.tinkerpop.pipes.Pipe;
-import com.tinkerpop.pipes.sideeffect.SideEffectPipe;
-import com.tinkerpop.pipes.util.AbstractMetaPipe;
-import com.tinkerpop.pipes.util.MetaPipe;
-import com.tinkerpop.pipes.util.PipeHelper;
-
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
+
+import com.tinkerpop.pipes.Pipe;
+import com.tinkerpop.pipes.sideeffect.SideEffectPipe;
+import com.tinkerpop.pipes.util.AbstractMetaPipe;
+import com.tinkerpop.pipes.util.FastNoSuchElementException;
+import com.tinkerpop.pipes.util.MetaPipe;
+import com.tinkerpop.pipes.util.PipeHelper;
 
 /**
  * The SideEffectCapPipe will yield an E that is the side effect of the provided SideEffectPipe.
@@ -41,7 +42,7 @@ public class SideEffectCapPipe<S, T> extends AbstractMetaPipe<S, T> implements M
             this.alive = false;
             return this.pipeToCap.getSideEffect();
         } else {
-            throw new NoSuchElementException();
+            throw FastNoSuchElementException.instance();
         }
     }
 

--- a/src/main/java/com/tinkerpop/pipes/util/FastNoSuchElementException.java
+++ b/src/main/java/com/tinkerpop/pipes/util/FastNoSuchElementException.java
@@ -1,0 +1,22 @@
+package com.tinkerpop.pipes.util;
+
+import java.util.NoSuchElementException;
+
+public class FastNoSuchElementException extends NoSuchElementException {
+
+	private static final long serialVersionUID = 2303108654138257697L;
+	private static final FastNoSuchElementException instance = new FastNoSuchElementException();
+
+	/**
+	 * Retrieve a singleton, fast {@link NoSuchElementException} without a stack trace.
+	 */
+	public static NoSuchElementException instance() {
+		return instance;
+	}
+
+	@Override
+	public synchronized Throwable fillInStackTrace() {
+		return this;
+	}
+
+}

--- a/src/main/java/com/tinkerpop/pipes/util/iterators/EmptyIterator.java
+++ b/src/main/java/com/tinkerpop/pipes/util/iterators/EmptyIterator.java
@@ -1,7 +1,8 @@
 package com.tinkerpop.pipes.util.iterators;
 
 import java.util.Iterator;
-import java.util.NoSuchElementException;
+
+import com.tinkerpop.pipes.util.FastNoSuchElementException;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
@@ -18,6 +19,6 @@ public enum EmptyIterator implements Iterator<Object> {
     }
 
     public Object next() {
-        throw new NoSuchElementException();
+        throw FastNoSuchElementException.instance();
     }
 }

--- a/src/main/java/com/tinkerpop/pipes/util/iterators/ExpandableMultiIterator.java
+++ b/src/main/java/com/tinkerpop/pipes/util/iterators/ExpandableMultiIterator.java
@@ -3,7 +3,8 @@ package com.tinkerpop.pipes.util.iterators;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
-import java.util.NoSuchElementException;
+
+import com.tinkerpop.pipes.util.FastNoSuchElementException;
 
 /**
  * @author Marko A. Rodriguez (http://markorodriguez.com)
@@ -43,7 +44,7 @@ public class ExpandableMultiIterator<T> implements Iterator<T> {
                 if (this.iterators.hasNext()) {
                     this.currentIterator = this.iterators.next();
                 } else {
-                    throw new NoSuchElementException();
+                    throw FastNoSuchElementException.instance();
                 }
             }
         }

--- a/src/main/java/com/tinkerpop/pipes/util/iterators/MultiIterator.java
+++ b/src/main/java/com/tinkerpop/pipes/util/iterators/MultiIterator.java
@@ -3,7 +3,8 @@ package com.tinkerpop.pipes.util.iterators;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
-import java.util.NoSuchElementException;
+
+import com.tinkerpop.pipes.util.FastNoSuchElementException;
 
 /**
  * MultiIterator takes multiple iterators in its constructor and makes them behave like a single iterator.
@@ -38,7 +39,7 @@ public class MultiIterator<T> implements Iterator<T> {
                 if (this.iterators.hasNext()) {
                     this.currentIterator = this.iterators.next();
                 } else {
-                    throw new NoSuchElementException();
+                    throw FastNoSuchElementException.instance();
                 }
             }
         }

--- a/src/main/java/com/tinkerpop/pipes/util/iterators/SingleExpandableIterator.java
+++ b/src/main/java/com/tinkerpop/pipes/util/iterators/SingleExpandableIterator.java
@@ -1,7 +1,8 @@
 package com.tinkerpop.pipes.util.iterators;
 
 import java.util.Iterator;
-import java.util.NoSuchElementException;
+
+import com.tinkerpop.pipes.util.FastNoSuchElementException;
 
 /**
  * SingleExpandableIterator can have an object added to it. However, it only stores one object.
@@ -41,7 +42,7 @@ public class SingleExpandableIterator<T> implements Iterator<T> {
             this.alive = false;
             return this.t;
         } else {
-            throw new NoSuchElementException();
+            throw FastNoSuchElementException.instance();
         }
     }
 }

--- a/src/main/java/com/tinkerpop/pipes/util/iterators/SingleIterator.java
+++ b/src/main/java/com/tinkerpop/pipes/util/iterators/SingleIterator.java
@@ -1,7 +1,8 @@
 package com.tinkerpop.pipes.util.iterators;
 
 import java.util.Iterator;
-import java.util.NoSuchElementException;
+
+import com.tinkerpop.pipes.util.FastNoSuchElementException;
 
 /**
  * SingleIterator is an iterator that only contains one object of type T.
@@ -32,7 +33,7 @@ public class SingleIterator<T> implements Iterator<T> {
             this.alive = false;
             return this.t;
         } else {
-            throw new NoSuchElementException();
+            throw FastNoSuchElementException.instance();
         }
     }
 }

--- a/src/main/java/com/tinkerpop/pipes/util/structures/ArrayQueue.java
+++ b/src/main/java/com/tinkerpop/pipes/util/structures/ArrayQueue.java
@@ -1,8 +1,9 @@
 package com.tinkerpop.pipes.util.structures;
 
 import java.util.ArrayList;
-import java.util.NoSuchElementException;
 import java.util.Queue;
+
+import com.tinkerpop.pipes.util.FastNoSuchElementException;
 
 /**
  * A Queue implementation that does not remove items when "drained," but instead, simply makes use of a counter.
@@ -16,7 +17,7 @@ public class ArrayQueue<T> extends ArrayList<T> implements Queue<T> {
 
     public T remove() {
         if (this.current >= this.size())
-            throw new NoSuchElementException();
+            throw FastNoSuchElementException.instance();
         else
             return this.get(this.current++);
     }
@@ -46,7 +47,7 @@ public class ArrayQueue<T> extends ArrayList<T> implements Queue<T> {
 
     public T element() {
         if (this.current >= this.size())
-            throw new NoSuchElementException();
+            throw FastNoSuchElementException.instance();
         else
             return peek();
     }

--- a/src/test/java/com/tinkerpop/pipes/util/iterators/SingleIteratorTest.java
+++ b/src/test/java/com/tinkerpop/pipes/util/iterators/SingleIteratorTest.java
@@ -1,6 +1,9 @@
 package com.tinkerpop.pipes.util.iterators;
 
 import com.tinkerpop.pipes.TimingTest;
+import com.tinkerpop.pipes.filter.BackFilterPipe;
+import com.tinkerpop.pipes.filter.FilterPipe;
+import com.tinkerpop.pipes.transform.IdentityPipe;
 
 import java.util.Arrays;
 import java.util.NoSuchElementException;
@@ -50,6 +53,18 @@ public class SingleIteratorTest extends TimingTest {
             new SingleIterator<String>("marko").next();
         }
         printPerformance("SingleIterator for single object", numberToDo, "iterators constructed and next()'d", this.stopWatch());
+
+        this.stopWatch();
+        for (int i = 0; i < numberToDo; i++) {
+           SingleIterator<String> iterator = new SingleIterator<String>("marko");
+           iterator.next();
+			try {
+				iterator.next();
+			} catch (NoSuchElementException e) {
+				// Ignore
+			}
+        }
+        printPerformance("SingleIterator for single object", numberToDo, "iterators constructed and next()'d twice to cause NoSuchElementException", this.stopWatch());
     }
 
 


### PR DESCRIPTION
This adds a NoSuchElementException subclass, FastNoSuchElementException, that provides a static instance. This requires no change to method signatures, only the throw needs to be changed:

```
throw new FastNoSuchElementException.instance()
```

Background is discussed here:

https://groups.google.com/forum/?fromgroups#!topic/gremlin-users/t7T0A-QRJX8

There's no particular problem with exceptions or try/catch as a pattern for flow control, the overhead of exception _handling_ is largely overblown, but the CPU overhead of fillInStackTrace and object allocation of the stack frames and exception object itself is not.

Comparisons between three approaches using 100000 iterators constructed in a loop and next() called twice to cause NoSuchElementException:

```
throw new NoSuchElementException() (current): 295.4235050678253ms
throw new FastNoSuchElementException(): 26.63270902633667ms
throw new FastNoSuchElementException.instance(): 13.198302030563354ms
```
