### PR TITLE
Added @Pipeline.cast@ to allow pipeline end type to be reset.

### DIFF
--- a/CHANGELOG.textile
+++ b/CHANGELOG.textile
@@ -6,6 +6,10 @@ h2. Pipes 2.y.z
 
 !https://github.com/tinkerpop/pipes/raw/master/doc/images/pipes-2.png!
 
+h3. Version 2.4.0 (NOT OFFICIALLY RELEASE YET)
+
+* Added @Pipeline.cast@ to allow pipeline end type to be reset.
+
 h3. Version 2.3.0 (March 20, 2013)
 
 ```xml

--- a/src/main/java/com/tinkerpop/pipes/util/Pipeline.java
+++ b/src/main/java/com/tinkerpop/pipes/util/Pipeline.java
@@ -148,6 +148,16 @@ public class Pipeline<S, E> implements Pipe<S, E>, MetaPipe {
     public Iterator<E> iterator() {
         return this;
     }
+    
+    /**
+     * Returns the current pipeline with a new end type.
+     * Useful if the end type of the pipeline cannot be implicitly derived. 
+     *
+     * @return returns the current pipeline with the new end type.
+     */
+    public <E> Pipeline<S, E> cast(Class<E> end) {
+        return (Pipeline<S, E>) this;
+    }
 
     public String toString() {
         return this.pipes.toString();

--- a/src/test/java/com/tinkerpop/pipes/util/PipelineTest.java
+++ b/src/test/java/com/tinkerpop/pipes/util/PipelineTest.java
@@ -24,6 +24,22 @@ public class PipelineTest extends TestCase {
         pipeline.reset();
         assertTrue(pipeline.hasNext());
         pipeline.reset();
-        assertFalse(pipeline.hasNext()); // Pipe has consumed and reset has thrown away both items.
+        assertFalse(pipeline.hasNext()); // Pipe has consumed and reset has
+                                         // thrown away both items.
+    }
+
+    public void testPipelineCast() {
+
+        Pipeline<String, String> pipeline = new Pipeline<String, String>(new IdentityPipe<String>());
+        pipeline.setStarts(Arrays.asList("marko", "peter"));
+        Pipeline<String, Integer> cast = pipeline.cast(Integer.class);
+        assertTrue(((Object) pipeline) == ((Object) cast));
+        try {
+            Integer next = cast.next();
+            fail("Value was actually a string");
+        } catch (ClassCastException e) {
+
+        }
+
     }
 }


### PR DESCRIPTION
Currently if a Java client uses a function that loses the end type of then they have to recast the pipeline if they want to use the for-each syntax, e.g:

``` java
GremlinPipeline<Vertex, Edge> p = new GremlinPipeline<Vertex, Edge>();
for (Edge e : (GremlinPipeline<Vertex, Edge>)p.outE("permission-of").as("permission").inV().back("permission")) {
//Stuff
}
```

Adding a cast function allows the end type to be manually set without the noise of casting.

``` java
GremlinPipeline<Vertex, Edge> p = new GremlinPipeline<Vertex, Edge>();
for (Edge e : p.outE("permission-of").as("permission").inV().back("permission").cast(Edge.class)) {
//Stuff
}
```
