### PR TITLE
Refactor Table class so it will compile against Java 8 #84

### DIFF
--- a/src/main/java/com/tinkerpop/pipes/util/structures/Table.java
+++ b/src/main/java/com/tinkerpop/pipes/util/structures/Table.java
@@ -143,26 +143,21 @@ public class Table extends ArrayList<Row> {
      * @return a newly created sorted table
      */
     public Table sort() {
-        final Table temp = Table.cloneTableStructure(this);
-        final List<Row> rows = new ArrayList<Row>();
-        for (final Row row : this) {
-            rows.add(row);
-        }
-        Collections.sort(rows, Table.getDefaultRowComparator());
-        temp.addAll(rows);
-        return temp;
+      return Table.sort(this, Table.getDefaultRowComparator());
     }
 
     /**
-     * Sort the rows of the table according to provided comparator
+     * Sort the rows of the table according to provided comparator. The original table
+     * is not modified.
      *
+     * @param table the table to sort
      * @param comparator a row comparator
      * @return a newly created sorted table
      */
-    public Table sort(Comparator<Row> comparator) {
-        final Table temp = Table.cloneTableStructure(this);
+    public static Table sort(Table table, Comparator<Row> comparator) {
+        final Table temp = Table.cloneTableStructure(table);
         final List<Row> rows = new ArrayList<Row>();
-        for (final Row row : this) {
+        for (final Row row : table) {
             rows.add(row);
         }
         Collections.sort(rows, comparator);

--- a/src/test/java/com/tinkerpop/pipes/util/structures/TableTest.java
+++ b/src/test/java/com/tinkerpop/pipes/util/structures/TableTest.java
@@ -163,7 +163,7 @@ public class TableTest extends TestCase {
         assertEquals(temp.get(1, 0), "bobby");
         assertEquals(temp.get(2, 0), "cabby");
 
-        temp = table.sort(new Comparator<Row>() {
+        temp = Table.sort(table, new Comparator<Row>() {
             public int compare(Row a, Row b) {
                 return ((Comparable) a.get(1)).compareTo(b.get(1));
             }


### PR DESCRIPTION
Made the existing Table::sort method static so that it will not
clash with the virtual extension method on ArrayList in Java8.
