### PR TITLE
Allow subclasses of Vertex and Edge

### DIFF
--- a/src/main/java/com/tinkerpop/pipes/transform/QueryPipe.java
+++ b/src/main/java/com/tinkerpop/pipes/transform/QueryPipe.java
@@ -28,7 +28,7 @@ public abstract class QueryPipe<S, E extends Element> extends AbstractPipe<S, E>
     protected Iterator<E> currentIterator = PipeHelper.emptyIterator();
 
     public void setResultingElementClass(final Class<? extends Element> elementClass) {
-        if (!elementClass.equals(Vertex.class) && !elementClass.equals(Edge.class))
+        if (!Vertex.class.isAssignableFrom(elementClass) && !Edge.class.isAssignableFrom(elementClass))
             throw new IllegalArgumentException("The provided element class must be either Vertex or Edge");
 
         this.elementClass = (Class) elementClass;


### PR DESCRIPTION
Don't check for class equality, but inheritance. The old equality check made inheritance impossible (e.g. for ScalaVertex). IMHO we could just drop the two lines altogether (31/32) because the compiler verifies that it's an Element.
